### PR TITLE
Update to upstream P4C and add a usage example for gtests. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,14 @@ set(RTSMITH_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/core/fuzzer.cpp
 )
 
+# GTest source files for P4RuntimeSmith.
+set(RTSMITH_GTEST_SOURCES
+   # # XXX These should be in a library.
+  ${P4C_SOURCE_DIR}/test/gtest/helpers.cpp
+  ${P4C_SOURCE_DIR}/test/gtest/gtestp4c.cpp
+  test/core/rtsmith_api_test.cpp
+)
+
 # RTSmith libraries.
 set(RTSMITH_LIBS p4tools-common controlplane)
 
@@ -73,3 +81,17 @@ add_custom_target(
 )
 
 add_dependencies(p4rtsmith linkrtsmith)
+
+
+if(ENABLE_GTESTS)
+  add_executable(rtsmith-gtest ${RTSMITH_GTEST_SOURCES})
+  target_link_libraries(
+    rtsmith-gtest PRIVATE librtsmith PRIVATE gtest ${RTSMITH_LIBS} ${P4C_LIBRARIES} ${P4C_LIB_DEPS}
+  )
+
+  if(ENABLE_TESTING)
+    add_test(NAME rtsmith-gtest COMMAND rtsmith-gtest)
+    set_tests_properties(rtsmith-gtest PROPERTIES LABELS "gtest-flay")
+  endif()
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(RTSMITH_SOURCES
 )
 
 # RTSmith libraries.
-set(RTSMITH_LIBS p4tools-common)
+set(RTSMITH_LIBS p4tools-common controlplane)
 
 file(GLOB rtsmith_targets RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/targets
      ${CMAKE_CURRENT_SOURCE_DIR}/targets/*
@@ -55,8 +55,8 @@ endforeach()
 configure_file(register.h.in register.h)
 
 add_p4tools_library(librtsmith ${RTSMITH_SOURCES})
-add_dependencies(librtsmith p4tools-common controlplane)
-target_include_directories(librtsmith SYSTEM BEFORE PUBLIC ${Protobuf_INCLUDE_DIRS})
+add_dependencies(librtsmith p4tools-common)
+target_link_libraries(librtsmith PRIVATE controlplane)
 
 add_p4tools_executable(p4rtsmith main.cpp)
 

--- a/core/program_info.cpp
+++ b/core/program_info.cpp
@@ -1,15 +1,17 @@
 #include "backends/p4tools/modules/p4rtsmith/core/program_info.h"
 
+#include "backends/p4tools/common/compiler/compiler_target.h"
+
 namespace P4Tools::RTSmith {
 
-ProgramInfo::ProgramInfo(const IR::P4Program *program, P4::P4RuntimeAPI p4runtimeApi)
-    : program(program), p4runtimeApi(p4runtimeApi) {}
+ProgramInfo::ProgramInfo(const CompilerResult &compilerResult, P4::P4RuntimeAPI p4runtimeApi)
+    : compilerResult(compilerResult), p4runtimeApi(p4runtimeApi) {}
 
 /* =============================================================================================
  *  Getters
  * ============================================================================================= */
 
-const IR::P4Program *ProgramInfo::getProgram() const { return program; }
+const IR::P4Program *ProgramInfo::getProgram() const { return &compilerResult.get().getProgram(); }
 
 const P4::P4RuntimeAPI &ProgramInfo::getP4RuntimeApi() const { return p4runtimeApi; }
 

--- a/core/program_info.h
+++ b/core/program_info.h
@@ -1,6 +1,9 @@
 #ifndef BACKENDS_P4TOOLS_MODULES_P4RTSMITH_CORE_PROGRAM_INFO_H_
 #define BACKENDS_P4TOOLS_MODULES_P4RTSMITH_CORE_PROGRAM_INFO_H_
 
+#include <functional>
+
+#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "control-plane/p4RuntimeSerializer.h"
 #include "ir/ir.h"
 #include "lib/castable.h"
@@ -11,12 +14,12 @@ namespace P4Tools::RTSmith {
 class ProgramInfo : public ICastable {
  private:
     /// The P4 program from which this object is derived.
-    const IR::P4Program *program;
+    std::reference_wrapper<const CompilerResult> compilerResult;
 
     P4::P4RuntimeAPI p4runtimeApi;
 
  protected:
-    explicit ProgramInfo(const IR::P4Program *program, P4::P4RuntimeAPI p4runtimeApi);
+    explicit ProgramInfo(const CompilerResult &compilerResult, P4::P4RuntimeAPI p4runtimeApi);
 
  public:
     ProgramInfo(const ProgramInfo &) = default;

--- a/core/target.h
+++ b/core/target.h
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "backends/p4tools/common/core/target.h"
 #include "backends/p4tools/modules/p4rtsmith/core/fuzzer.h"
 #include "backends/p4tools/modules/p4rtsmith/core/program_info.h"
@@ -18,7 +19,7 @@ class RtSmithTarget : public Target {
     /// Produces a @ProgramInfo for the given P4 program.
     ///
     /// @returns nullptr if the program is not supported by this target.
-    static const ProgramInfo *produceProgramInfo(const IR::P4Program *program);
+    static const ProgramInfo *produceProgramInfo(const CompilerResult &compilerResult);
 
     /// @returns the fuzzer that will produce an initial configuration and a series of random write
     /// requests..
@@ -26,11 +27,12 @@ class RtSmithTarget : public Target {
 
  protected:
     /// @see @produceProgramInfo.
-    const ProgramInfo *produceProgramInfoImpl(const IR::P4Program *program) const;
+    [[nodiscard]] virtual const ProgramInfo *produceProgramInfoImpl(
+        const CompilerResult &compilerResult) const;
 
     /// @see @produceProgramInfo.
     virtual const ProgramInfo *produceProgramInfoImpl(
-        const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const = 0;
+        const CompilerResult &compilerResult, const IR::Declaration_Instance *mainDecl) const = 0;
 
     /// @see @getStepper.
     [[nodiscard]] virtual P4RuntimeFuzzer &getFuzzerImpl(const ProgramInfo &programInfo) const = 0;

--- a/core/util.h
+++ b/core/util.h
@@ -1,0 +1,71 @@
+#ifndef BACKENDS_P4TOOLS_MODULES_P4RTSMITH_CORE_UTIL_H_
+#define BACKENDS_P4TOOLS_MODULES_P4RTSMITH_CORE_UTIL_H_
+
+#include <map>
+#include <optional>
+
+namespace P4Tools::RTSmith {
+
+/// If @param inputFunction evaluates to false, returns @param ret.
+// NOLINTNEXTLINE
+#define RETURN_IF_FALSE(inputFunction, returnValue) \
+    if (!(inputFunction)) return returnValue;
+
+/// If @param inputFunction evaluates to false, returns @param ret and also executes @param
+/// errorFunction.
+// NOLINTNEXTLINE
+#define RETURN_IF_FALSE_WITH_MESSAGE(inputFunction, returnValue, errorFunction) \
+    if (!(inputFunction)) {                                                     \
+        errorFunction;                                                          \
+        return returnValue;                                                     \
+    }
+
+// Internal helper for concatenating macro values.
+#define STATUS_MACROS_CONCAT_NAME_INNER(x, y) x##y
+#define STATUS_MACROS_CONCAT_NAME(x, y) STATUS_MACROS_CONCAT_NAME_INNER(x, y)
+
+/// Assigns the value of @param inputFunction to @param targetVariable if the contained value is not
+/// false.
+// NOLINTNEXTLINE
+#define ASSIGN_OR_RETURN_IMPL(temporary, targetVariable, inputFunction, returnValue) \
+    auto temporary = inputFunction;                                                  \
+    if (!(temporary)) return returnValue;                                            \
+    targetVariable = *(temporary);  // NOLINT
+
+#define ASSIGN_OR_RETURN(targetVariable, inputFunction, returnValue)                      \
+    ASSIGN_OR_RETURN_IMPL(STATUS_MACROS_CONCAT_NAME(temporary, __LINE__), targetVariable, \
+                          inputFunction, returnValue)
+
+#define ASSIGN_OR_RETURN_WITH_MESSAGE_IMPL(temporary, targetVariable, inputFunction, returnValue, \
+                                           errorFunction)                                         \
+    auto temporary = inputFunction;                                                               \
+    if (!(temporary)) {                                                                           \
+        errorFunction;                                                                            \
+        return returnValue;                                                                       \
+    }                                                                                             \
+    targetVariable = *(temporary);  // NOLINT
+
+#define ASSIGN_OR_RETURN_WITH_MESSAGE(targetVariable, inputFunction, returnValue, errorFunction) \
+    ASSIGN_OR_RETURN_WITH_MESSAGE_IMPL(STATUS_MACROS_CONCAT_NAME(temporary, __LINE__),           \
+                                       targetVariable, inputFunction, returnValue, errorFunction)
+
+/// Assigns the value of @param inputFunction to @param targetVariable if the contained value is not
+/// false.
+/// @param inputFunction is dereferenced, which will work on std::nullopt and pointers, but not
+/// bools. Prints an error provided with @param errorFunction if the inputFunction evaluates to
+/// false.
+// NOLINTNEXTLINE
+
+/// Tries to look up a key in a map, returns std::nullopt if the key does not exist.
+template <class K, class T, class V, class Comp, class Alloc>
+inline std::optional<V> safeAt(const std::map<K, V, Comp, Alloc> &m, T key) {
+    auto it = m.find(key);
+    if (it != m.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+}  // namespace P4Tools::RTSmith
+
+#endif /* BACKENDS_P4TOOLS_MODULES_P4RTSMITH_CORE_UTIL_H_ */

--- a/rtsmith.cpp
+++ b/rtsmith.cpp
@@ -4,10 +4,11 @@
 
 #include <cstdlib>
 
+#include "backends/p4tools/common/compiler/context.h"
 #include "backends/p4tools/common/lib/logging.h"
 #include "backends/p4tools/modules/p4rtsmith/core/target.h"
+#include "backends/p4tools/modules/p4rtsmith/core/util.h"
 #include "backends/p4tools/modules/p4rtsmith/register.h"
-#include "frontends/common/parseInput.h"
 #include "lib/error.h"
 
 namespace P4Tools::RTSmith {
@@ -25,12 +26,7 @@ int RtSmith::mainImpl(const CompilerResult &compilerResult) {
 
     enableInformationLogging();
 
-    auto seed = Utils::getCurrentSeed();
-    if (seed) {
-        printFeature("test_info", 4, "============ Program seed %1% =============\n", *seed);
-    }
-
-    const auto *programInfo = RtSmithTarget::produceProgramInfo(&compilerResult.getProgram());
+    const auto *programInfo = RtSmithTarget::produceProgramInfo(compilerResult);
     if (programInfo == nullptr) {
         ::error("Program not supported by target device and architecture.");
         return EXIT_FAILURE;
@@ -58,6 +54,86 @@ int RtSmith::mainImpl(const CompilerResult &compilerResult) {
     }
 
     return ::errorCount() == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+std::optional<RtSmithResult> generateConfigImpl(
+    std::optional<std::reference_wrapper<const std::string>> program,
+    const CompilerOptions &compilerOptions, const RtSmithOptions & /*rtSmithOptions*/) {
+    // Register supported compiler targets.
+    registerCompilerTargets();
+
+    // Register supported P4RTSmith targets.
+    registerRtSmithTargets();
+
+    P4Tools::Target::init(compilerOptions.target.c_str(), compilerOptions.arch.c_str());
+
+    // Set up the compilation context.
+    auto *compileContext = new CompileContext<CompilerOptions>();
+    compileContext->options() = compilerOptions;
+    AutoCompileContext autoContext(compileContext);
+
+    CompilerResultOrError compilerResult;
+    if (program.has_value()) {
+        // Run the compiler to get an IR and invoke the tool.
+        ASSIGN_OR_RETURN(compilerResult,
+                         P4Tools::CompilerTarget::runCompiler(program.value().get()), std::nullopt);
+    } else {
+        RETURN_IF_FALSE_WITH_MESSAGE(!compilerOptions.file.isNullOrEmpty(), std::nullopt,
+                                     ::error("Expected a file input."));
+        // Run the compiler to get an IR and invoke the tool.
+        ASSIGN_OR_RETURN(compilerResult, P4Tools::CompilerTarget::runCompiler(), std::nullopt);
+    }
+
+    const auto *programInfo = RtSmithTarget::produceProgramInfo(compilerResult.value());
+    if (programInfo == nullptr || ::errorCount() > 0) {
+        ::error("P4RTSmith encountered errors during preprocessing.");
+        return std::nullopt;
+    }
+
+    auto p4RuntimeApi = programInfo->getP4RuntimeApi();
+    printInfo("Inferred API:\n%1%", p4RuntimeApi.p4Info->DebugString());
+
+    auto &fuzzer = RtSmithTarget::getFuzzer(*programInfo);
+
+    auto initialConfig = fuzzer.produceInitialConfig();
+    printInfo("Generated initial configuration:");
+    for (const auto &writeRequest : initialConfig) {
+        printInfo("%1%", writeRequest.DebugString());
+    }
+
+    auto timeSeriesUpdates = fuzzer.produceUpdateTimeSeries();
+    printInfo("Time series updates:");
+    for (const auto &[time, writeRequest] : timeSeriesUpdates) {
+        printInfo("Time %1%:\n%2%", writeRequest.DebugString());
+    }
+    return {{initialConfig, timeSeriesUpdates}};
+}
+
+std::optional<RtSmithResult> RtSmith::generateConfig(const std::string &program,
+                                                     const CompilerOptions &compilerOptions,
+                                                     const RtSmithOptions &rtSmithOptions) {
+    try {
+        return generateConfigImpl(program, compilerOptions, rtSmithOptions);
+    } catch (const std::exception &e) {
+        std::cerr << "Internal error: " << e.what() << "\n";
+        return std::nullopt;
+    } catch (...) {
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+std::optional<RtSmithResult> RtSmith::generateConfig(const CompilerOptions &compilerOptions,
+                                                     const RtSmithOptions &rtSmithOptions) {
+    try {
+        return generateConfigImpl(std::nullopt, compilerOptions, rtSmithOptions);
+    } catch (const std::exception &e) {
+        std::cerr << "Internal error: " << e.what() << "\n";
+        return std::nullopt;
+    } catch (...) {
+        return std::nullopt;
+    }
+    return std::nullopt;
 }
 
 }  // namespace P4Tools::RTSmith

--- a/rtsmith.h
+++ b/rtsmith.h
@@ -2,9 +2,15 @@
 #define BACKENDS_P4TOOLS_MODULES_P4RTSMITH_RTSMITH_H_
 
 #include "backends/p4tools/common/p4ctool.h"
+#include "backends/p4tools/modules/p4rtsmith/core/fuzzer.h"
 #include "backends/p4tools/modules/p4rtsmith/options.h"
 
 namespace P4Tools::RTSmith {
+
+struct RtSmithResult {
+    InitialP4RuntimeConfig config;
+    P4RuntimeUpdateSeries updateSeries;
+};
 
 /// This is main implementation of the P4RuntimeSmith tool.
 class RtSmith : public AbstractP4cTool<RtSmithOptions> {
@@ -15,6 +21,13 @@ class RtSmith : public AbstractP4cTool<RtSmithOptions> {
 
  public:
     virtual ~RtSmith() = default;
+
+    static std::optional<RtSmithResult> generateConfig(const std::string &program,
+                                                       const CompilerOptions &compilerOptions,
+                                                       const RtSmithOptions &rtSmithOptions);
+
+    static std::optional<RtSmithResult> generateConfig(const CompilerOptions &compilerOptions,
+                                                       const RtSmithOptions &rtSmithOptions);
 };
 
 }  // namespace P4Tools::RTSmith

--- a/targets/bmv2/program_info.cpp
+++ b/targets/bmv2/program_info.cpp
@@ -12,7 +12,8 @@
 
 namespace P4Tools::RTSmith::V1Model {
 
-Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(const IR::P4Program *program)
-    : ProgramInfo(program, P4::P4RuntimeSerializer::get()->generateP4Runtime(program, "v1model")) {}
+Bmv2V1ModelProgramInfo::Bmv2V1ModelProgramInfo(const CompilerResult &compilerResult)
+    : ProgramInfo(compilerResult, P4::P4RuntimeSerializer::get()->generateP4Runtime(
+                                      &compilerResult.getProgram(), "v1model")) {}
 
 }  // namespace P4Tools::RTSmith::V1Model

--- a/targets/bmv2/program_info.h
+++ b/targets/bmv2/program_info.h
@@ -1,6 +1,7 @@
 #ifndef BACKENDS_P4TOOLS_MODULES_P4RTSMITH_TARGETS_BMV2_PROGRAM_INFO_H_
 #define BACKENDS_P4TOOLS_MODULES_P4RTSMITH_TARGETS_BMV2_PROGRAM_INFO_H_
 
+#include "backends/p4tools/common/compiler/compiler_target.h"
 #include "backends/p4tools/modules/p4rtsmith/core/program_info.h"
 #include "ir/ir.h"
 #include "ir/node.h"
@@ -9,7 +10,7 @@ namespace P4Tools::RTSmith::V1Model {
 
 class Bmv2V1ModelProgramInfo : public ProgramInfo {
  public:
-    explicit Bmv2V1ModelProgramInfo(const IR::P4Program *program);
+    explicit Bmv2V1ModelProgramInfo(const CompilerResult &compilerResult);
 
     DECLARE_TYPEINFO(Bmv2V1ModelProgramInfo);
 };

--- a/targets/bmv2/target.cpp
+++ b/targets/bmv2/target.cpp
@@ -20,8 +20,8 @@ void Bmv2V1ModelRtSmithTarget::make() {
 }
 
 const ProgramInfo *Bmv2V1ModelRtSmithTarget::produceProgramInfoImpl(
-    const IR::P4Program *program, const IR::Declaration_Instance * /*mainDecl*/) const {
-    return new Bmv2V1ModelProgramInfo(program);
+    const CompilerResult &compilerResult, const IR::Declaration_Instance * /*mainDecl*/) const {
+    return new Bmv2V1ModelProgramInfo(compilerResult);
 }
 
 Bmv2V1ModelFuzzer &Bmv2V1ModelRtSmithTarget::getFuzzerImpl(const ProgramInfo &programInfo) const {

--- a/targets/bmv2/target.h
+++ b/targets/bmv2/target.h
@@ -18,7 +18,8 @@ class Bmv2V1ModelRtSmithTarget : public RtSmithTarget {
 
  protected:
     const ProgramInfo *produceProgramInfoImpl(
-        const IR::P4Program *program, const IR::Declaration_Instance *mainDecl) const override;
+        const CompilerResult &compilerResult,
+        const IR::Declaration_Instance *mainDecl) const override;
 
     [[nodiscard]] Bmv2V1ModelFuzzer &getFuzzerImpl(const ProgramInfo &programInfo) const override;
 };

--- a/test/core/rtsmith_api_test.cpp
+++ b/test/core/rtsmith_api_test.cpp
@@ -1,0 +1,102 @@
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+#include "backends/p4tools/modules/p4rtsmith/rtsmith.h"
+#include "test/gtest/helpers.h"
+
+namespace Test {
+
+namespace {
+
+std::string generateTestProgram(const char *ingressBlock) {
+    std::stringstream templateString;
+    templateString << R"p4(
+header ethernet_t {
+    bit<48> dst_addr;
+    bit<48> src_addr;
+    bit<16> ether_type;
+}
+struct Headers {
+  ethernet_t eth_hdr;
+}
+struct Metadata {  }
+parser parse(packet_in pkt, out Headers hdr, inout Metadata m, inout standard_metadata_t sm) {
+  state start {
+      pkt.extract(hdr.eth_hdr);
+      transition accept;
+  }
+}
+control ingress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t sm) {)p4"
+                   << ingressBlock << R"p4(
+}
+control egress(inout Headers hdr, inout Metadata meta, inout standard_metadata_t sm) {
+  apply {}
+}
+control deparse(packet_out pkt, in Headers hdr) {
+  apply {
+    pkt.emit(hdr.eth_hdr);
+  }
+}
+control verifyChecksum(inout Headers hdr, inout Metadata meta) {
+  apply {}
+}
+control computeChecksum(inout Headers hdr, inout Metadata meta) {
+  apply {}
+}
+V1Switch(parse(), verifyChecksum(), ingress(), egress(), computeChecksum(), deparse()) main;
+)p4";
+    return P4_SOURCE(P4Headers::V1MODEL, templateString.str().c_str());
+}
+
+CompilerOptions generateDefaultApiTestCompilerOptions() {
+    auto compilerOptions = CompilerOptions();
+    compilerOptions.target = "bmv2";
+    compilerOptions.arch = "v1model";
+    return compilerOptions;
+}
+
+P4Tools::RtSmithOptions &generateDefaultApiTestRtSmithOptions() {
+    auto &rtsmithOptions = P4Tools::RtSmithOptions::get();
+
+    return rtsmithOptions;
+}
+
+/// Helper methods to build configurations for Optimization Tests.
+class P4RuntimeApiTest : public ::testing::Test {};
+
+// Tests for the optimization of various expressions.
+TEST_F(P4RuntimeApiTest, GeneratesATestViaTheApi) {
+    auto source = generateTestProgram(R"(
+    // Drop the packet.
+    action acl_drop() {
+        mark_to_drop(sm);
+    }
+
+    table drop_table {
+        key = {
+            hdr.eth_hdr.dst_addr : ternary @name("dst_eth");
+        }
+        actions = {
+            acl_drop();
+            @defaultonly NoAction();
+        }
+    }
+
+    apply {
+        if (hdr.eth_hdr.isValid()) {
+            drop_table.apply();
+        }
+    })");
+    auto compilerOptions = generateDefaultApiTestCompilerOptions();
+    auto &rtsmithOptions = generateDefaultApiTestRtSmithOptions();
+
+    auto rtSmithResultOpt =
+        P4Tools::RTSmith::RtSmith::generateConfig(source, compilerOptions, rtsmithOptions);
+    ASSERT_TRUE(rtSmithResultOpt.has_value());
+}
+
+}  // anonymous namespace
+
+}  // namespace Test


### PR DESCRIPTION
You can run the gtest with this command: `./backends/p4tools/modules/p4rtsmith/rtsmith-gtest --gtest_filter="P4RuntimeApiTest*"`

It will do nothing, just test the API. I will clean this code up later. 