### PR TITLE
Fix producing initial config

### DIFF
--- a/core/fuzzer.cpp
+++ b/core/fuzzer.cpp
@@ -139,8 +139,7 @@ std::optional<p4::v1::FieldMatch> P4RuntimeFuzzer::produceMatchField(
 /// @return A table entry
 p4::v1::TableEntry P4RuntimeFuzzer::produceTableEntry(
     const p4::config::v1::Table &table,
-    const google::protobuf::RepeatedPtrField<p4::config::v1::Action> &actions,
-    uint64_t maxEntryGenCnt) {
+    const google::protobuf::RepeatedPtrField<p4::config::v1::Action> &actions) {
     p4::v1::TableEntry protoEntry;
 
     // set table id
@@ -149,9 +148,9 @@ p4::v1::TableEntry P4RuntimeFuzzer::produceTableEntry(
 
     // add matches
     const auto &matchFields = table.match_fields();
-    for (auto fieldId = 1; (uint64_t)fieldId <= maxEntryGenCnt; fieldId++) {
-        auto matchId = Utils::getRandInt(matchFields.size() - 1);
-        auto match = matchFields[matchId];
+    for (auto i = 0; i < matchFields.size(); i++) {
+        auto match = matchFields[i];
+        auto fieldId = match.id();
         auto protoMatch = produceMatchField(match, fieldId);
         *protoEntry.add_match() = *protoMatch;
     }

--- a/core/fuzzer.h
+++ b/core/fuzzer.h
@@ -50,8 +50,7 @@ class P4RuntimeFuzzer {
                                                                 int fieldId);
     virtual p4::v1::TableEntry produceTableEntry(
         const p4::config::v1::Table &table,
-        const google::protobuf::RepeatedPtrField<p4::config::v1::Action> &actions,
-        uint64_t maxEntryGenCnt);
+        const google::protobuf::RepeatedPtrField<p4::config::v1::Action> &actions);
 
     virtual InitialP4RuntimeConfig produceInitialConfig() = 0;
 

--- a/options.cpp
+++ b/options.cpp
@@ -86,7 +86,9 @@ bool RtSmithOptions::printToStdout() const { return printToStdout_; }
 
 std::optional<std::string> RtSmithOptions::getConfigFilePath() const { return configFilePath; }
 
-std::optional<std::filesystem::path> RtSmithOptions::p4InfoFilePath() const { return _p4InfoFilePath; }
+std::optional<std::filesystem::path> RtSmithOptions::p4InfoFilePath() const {
+    return _p4InfoFilePath;
+}
 
 std::string_view RtSmithOptions::controlPlaneApi() const { return _controlPlaneApi; }
 

--- a/options.cpp
+++ b/options.cpp
@@ -86,9 +86,7 @@ bool RtSmithOptions::printToStdout() const { return printToStdout_; }
 
 std::optional<std::string> RtSmithOptions::getConfigFilePath() const { return configFilePath; }
 
-std::optional<std::filesystem::path> RtSmithOptions::p4InfoFilePath() const {
-    return _p4InfoFilePath;
-}
+std::optional<std::filesystem::path> RtSmithOptions::p4InfoFilePath() const { return _p4InfoFilePath; }
 
 std::string_view RtSmithOptions::controlPlaneApi() const { return _controlPlaneApi; }
 

--- a/targets/bmv2/fuzzer.cpp
+++ b/targets/bmv2/fuzzer.cpp
@@ -22,19 +22,22 @@ InitialP4RuntimeConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
     const auto actions = p4Info->actions();
 
     auto tableCnt = tables.size();
-    auto tableGenCnt = Utils::getRandInt(tableCnt);
 
-    for (auto i = 0; (uint64_t)i < tableGenCnt; i++) {
-        auto tableId = Utils::getRandInt(tableCnt - 1);
+    for (auto tableId = 0; tableId < tableCnt; tableId++) {
+        // NOTE: temporary use a coin to decide if generating entries for the table
+        if (Utils::getRandInt(0, 1) == 0) {
+            continue;
+        }
         auto table = tables.Get(tableId);
         auto maxEntryGenCnt = table.size();
+        for (auto i = 0; i < maxEntryGenCnt; i++) {
+            p4::v1::Update update;
+            update.set_type(p4::v1::Update_Type::Update_Type_INSERT);
 
-        p4::v1::Update update;
-        update.set_type(p4::v1::Update_Type::Update_Type_INSERT);
-
-        auto tableEntry = produceTableEntry(table, actions, maxEntryGenCnt);
-        *update.mutable_entity()->mutable_table_entry() = tableEntry;
-        *request.add_updates() = update;
+            auto tableEntry = produceTableEntry(table, actions);
+            *update.mutable_entity()->mutable_table_entry() = tableEntry;
+            *request.add_updates() = update;
+        }
     }
 
     std::vector<p4::v1::WriteRequest> requests{request};

--- a/targets/tofino/fuzzer.cpp
+++ b/targets/tofino/fuzzer.cpp
@@ -27,12 +27,11 @@ InitialP4RuntimeConfig TofinoTnaFuzzer::produceInitialConfig() {
     for (auto i = 0; (uint64_t)i < tableGenCnt; i++) {
         auto tableId = Utils::getRandInt(tableCnt - 1);
         auto table = tables.Get(tableId);
-        auto maxEntryGenCnt = table.size();
 
         p4::v1::Update update;
         update.set_type(p4::v1::Update_Type::Update_Type_INSERT);
 
-        auto tableEntry = produceTableEntry(table, actions, maxEntryGenCnt);
+        auto tableEntry = produceTableEntry(table, actions);
         *update.mutable_entity()->mutable_table_entry() = tableEntry;
         *request.add_updates() = update;
     }


### PR DESCRIPTION
Original version put all `match` for different update entity into the same entity. This PR fixes that.