### PR TITLE
Fix Xfails for BMV2

### DIFF
--- a/core/fuzzer.cpp
+++ b/core/fuzzer.cpp
@@ -132,10 +132,6 @@ p4::v1::TableEntry P4RuntimeFuzzer::produceTableEntry(
     const auto &matchFields = table.match_fields();
     for (auto i = 0; i < matchFields.size(); i++) {
         auto match = matchFields[i];
-        /// TODO: add this back once Flay supports OPTIONAL.
-        if (match.match_type() == p4::config::v1::MatchField::OPTIONAL) {
-            continue;
-        }
         protoEntry.add_match()->CopyFrom(produceMatchField(match));
     }
 

--- a/core/fuzzer.cpp
+++ b/core/fuzzer.cpp
@@ -40,6 +40,18 @@ p4::v1::FieldMatch_Ternary P4RuntimeFuzzer::produceFieldMatch_Ternary(int bitwid
     return protoTernary;
 }
 
+p4::v1::FieldMatch_Range P4RuntimeFuzzer::produceFieldMatch_Range(int bitwidth) {
+    p4::v1::FieldMatch_Range protoRange;
+    auto value1 = produceBytes(bitwidth);
+    auto value2 = produceBytes(bitwidth);
+    if (value1 > value2) {
+        std::swap(value1, value2);
+    }
+    protoRange.set_low(value1);
+    protoRange.set_high(value2);
+    return protoRange;
+}
+
 p4::v1::FieldMatch_Optional P4RuntimeFuzzer::produceFieldMatch_Optional(int bitwidth) {
     p4::v1::FieldMatch_Optional protoOptional;
     protoOptional.set_value(produceBytes(bitwidth));
@@ -108,6 +120,9 @@ p4::v1::FieldMatch P4RuntimeFuzzer::produceMatchField(p4::config::v1::MatchField
             break;
         case p4::config::v1::MatchField::TERNARY:
             protoMatch.mutable_ternary()->CopyFrom(produceFieldMatch_Ternary(bitwidth));
+            break;
+        case p4::config::v1::MatchField::RANGE:
+            protoMatch.mutable_range()->CopyFrom(produceFieldMatch_Range(bitwidth));
             break;
         case p4::config::v1::MatchField::OPTIONAL:
             protoMatch.mutable_optional()->CopyFrom(produceFieldMatch_Optional(bitwidth));

--- a/core/fuzzer.h
+++ b/core/fuzzer.h
@@ -38,6 +38,12 @@ class RuntimeFuzzer {
 
     /// Some Helper functions below
 
+    /// @brief Check `value` to a string of length `bitwidth`.
+    /// @param value
+    /// @param bitwidth
+    /// @return the result string.
+    static std::string checkBigIntToString(const big_int &value, int bitwidth);
+
     /// @brief Produce bytes in form of std::string given bitwidth.
     /// @param bitwidth
     /// @return A random bytes of length bitwidth in form of std::string.
@@ -47,7 +53,14 @@ class RuntimeFuzzer {
     /// @param bitwidth
     /// @param value
     /// @return A bytes of value of length bitwidth in form of std::string.
-    static std::string produceBytes(int bitwidth, big_int value);
+    static std::string produceBytes(int bitwidth, const big_int &value);
+
+    /// @brief Produce bytes within min and max in form of std::string given bitwidth.
+    /// @param bitwidth
+    /// @param min
+    /// @param max
+    /// @return A bytes of value of length bitwidth within min and max in form of std::string.
+    static std::string produceBytes(int bitwidth, const big_int &min, const big_int &max);
 
     static bool tableHasFieldType(const p4::config::v1::Table &table,
                                   const p4::config::v1::MatchField::MatchType type);

--- a/core/fuzzer.h
+++ b/core/fuzzer.h
@@ -67,6 +67,11 @@ class P4RuntimeFuzzer : public RuntimeFuzzer {
     /// @return A FieldMatch_Ternary
     virtual p4::v1::FieldMatch_Ternary produceFieldMatch_Ternary(int bitwidth);
 
+    /// @brief Produce a FieldMatch_Range with bitwidth
+    /// @param bitwidth
+    /// @return A FieldMatch_Range
+    virtual p4::v1::FieldMatch_Range produceFieldMatch_Range(int bitwidth);
+
     /// @brief Produce a FieldMatch_Optional with bitwidth
     /// @param bitwidth
     /// @return A FieldMatch_Optional

--- a/core/fuzzer.h
+++ b/core/fuzzer.h
@@ -28,6 +28,16 @@ class RuntimeFuzzer {
  public:
     explicit RuntimeFuzzer(const ProgramInfo &programInfo) : programInfo(programInfo) {}
 
+    /// @brief Produce an `InitialConfig`, which is a vector of updates.
+    /// @return A InitialConfig
+    virtual InitialConfig produceInitialConfig() = 0;
+
+    /// @brief Produce an `UpdateSeries`, which is a vector of indexed updates.
+    /// @return A InitialConfig
+    virtual UpdateSeries produceUpdateTimeSeries() = 0;
+
+    /// Some Helper functions below
+
     /// @brief Produce bytes in form of std::string given bitwidth.
     /// @param bitwidth
     /// @return A random bytes of length bitwidth in form of std::string.
@@ -39,13 +49,8 @@ class RuntimeFuzzer {
     /// @return A bytes of value of length bitwidth in form of std::string.
     static std::string produceBytes(int bitwidth, big_int value);
 
-    /// @brief Produce an `InitialConfig`, which is a vector of updates.
-    /// @return A InitialConfig
-    virtual InitialConfig produceInitialConfig() = 0;
-
-    /// @brief Produce an `UpdateSeries`, which is a vector of indexed updates.
-    /// @return A InitialConfig
-    virtual UpdateSeries produceUpdateTimeSeries() = 0;
+    static bool tableHasFieldType(const p4::config::v1::Table &table,
+                                  const p4::config::v1::MatchField::MatchType type);
 };
 
 class P4RuntimeFuzzer : public RuntimeFuzzer {

--- a/targets/bmv2/fuzzer.cpp
+++ b/targets/bmv2/fuzzer.cpp
@@ -28,7 +28,6 @@ InitialConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
         if (Utils::getRandInt(0, 1) == 0) {
             continue;
         }
-        printf("didn't skip by coin\n");
         auto table = tables.Get(tableId);
         if (table.match_fields_size() == 0 || table.is_const_table()) {
             continue;
@@ -37,7 +36,6 @@ InitialConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
         if (tableHasFieldType(table, p4::config::v1::MatchField::RANGE)) {
             continue;
         }
-        printf("trying generating\n");
         /// TODO: remove this `min`. It is for ease of debugging now.
         auto maxEntryGenCnt = std::min(table.size(), (int64_t)4);
         std::set<std::string> matchFields;
@@ -53,7 +51,6 @@ InitialConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
                 update->set_type(p4::v1::Update_Type::Update_Type_INSERT);
                 matchFields.insert(std::move(matchFieldString));
                 update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
-                printf("added %s\n", entry.DebugString().c_str());
             }
         }
     }

--- a/targets/bmv2/fuzzer.cpp
+++ b/targets/bmv2/fuzzer.cpp
@@ -32,10 +32,6 @@ InitialConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
         if (table.match_fields_size() == 0 || table.is_const_table()) {
             continue;
         }
-        /// TODO: Remove this when Flay supports RANGE.
-        if (tableHasFieldType(table, p4::config::v1::MatchField::RANGE)) {
-            continue;
-        }
         /// TODO: remove this `min`. It is for ease of debugging now.
         auto maxEntryGenCnt = std::min(table.size(), (int64_t)4);
         std::set<std::string> matchFields;

--- a/targets/bmv2/fuzzer.cpp
+++ b/targets/bmv2/fuzzer.cpp
@@ -29,6 +29,10 @@ InitialConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
             continue;
         }
         auto table = tables.Get(tableId);
+        if (table.match_fields_size() == 0) {
+            // Skip tables without match fields
+            continue;
+        }
         /// TODO: remove this `min`. It is for ease of debugging now.
         auto maxEntryGenCnt = std::min(table.size(), (int64_t)4);
         std::set<std::string> matchFields;

--- a/targets/bmv2/fuzzer.cpp
+++ b/targets/bmv2/fuzzer.cpp
@@ -29,8 +29,7 @@ InitialConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
             continue;
         }
         auto table = tables.Get(tableId);
-        if (table.match_fields_size() == 0) {
-            // Skip tables without match fields
+        if (table.match_fields_size() == 0 || table.is_const_table()) {
             continue;
         }
         /// TODO: remove this `min`. It is for ease of debugging now.

--- a/targets/bmv2/fuzzer.cpp
+++ b/targets/bmv2/fuzzer.cpp
@@ -30,12 +30,21 @@ InitialConfig Bmv2V1ModelFuzzer::produceInitialConfig() {
         }
         auto table = tables.Get(tableId);
         /// TODO: remove this `min`. It is for ease of debugging now.
-        auto maxEntryGenCnt = std::min(table.size(), (int64_t)2);
+        auto maxEntryGenCnt = std::min(table.size(), (int64_t)4);
+        std::set<std::string> matchFields;
         for (auto i = 0; i < maxEntryGenCnt; i++) {
             auto update = request->add_updates();
             update->set_type(p4::v1::Update_Type::Update_Type_INSERT);
-            update->mutable_entity()->mutable_table_entry()->CopyFrom(
-                produceTableEntry(table, actions));
+            auto entry = produceTableEntry(table, actions);
+            std::string matchFieldString;
+            for (const auto &match : entry.match()) {
+                match.AppendPartialToString(&matchFieldString);
+            }
+            if (matchFields.find(matchFieldString) == matchFields.end()) {
+                /// Only insert unique entries
+                matchFields.insert(std::move(matchFieldString));
+                update->mutable_entity()->mutable_table_entry()->CopyFrom(entry);
+            }
         }
     }
 

--- a/targets/bmv2/test/BMv2V1ModelXfail.cmake
+++ b/targets/bmv2/test/BMv2V1ModelXfail.cmake
@@ -6,201 +6,60 @@ p4tools_add_xfail_reason(
   "rtsmith-checker-bmv2-v1model"
   ""
   # P4C tests
-  action-two-params.p4
-  action_profile-bmv2.p4
-  action_profile_max_group_size_annotation.p4
-  action_profile_sum_of_members_annotation.p4
-  action_selector_shared-bmv2.p4
-  annotation-inline-propagate.p4
-  arith-bmv2.p4
-  arith1-bmv2.p4
-  arith2-bmv2.p4
-  arith3-bmv2.p4
-  arith4-bmv2.p4
-  arith5-bmv2.p4
-  basic_routing-bmv2.p4
-  bvec-hdr-bmv2.p4
-  checksum-l4-bmv2.p4
-  checksum1-bmv2.p4
-  concat-bmv2.p4
-  control-hs-index-test6.p4
-  copyprop1.p4
-  crc32-bmv2.p4
-  custom-type-restricted-fields.p4
-  def-use.p4
-  drop-bmv2.p4
-  flowlet_switching-bmv2.p4
-  gauntlet_action_return-bmv2.p4
-  gauntlet_exit_combination_1-bmv2.p4
-  gauntlet_exit_combination_10-bmv2.p4
-  gauntlet_exit_combination_11-bmv2.p4
-  gauntlet_exit_combination_13-bmv2.p4
-  gauntlet_exit_combination_14-bmv2.p4
-  gauntlet_exit_combination_15-bmv2.p4
-  gauntlet_exit_combination_16-bmv2.p4
-  gauntlet_exit_combination_17-bmv2.p4
-  gauntlet_exit_combination_19-bmv2.p4
-  gauntlet_exit_combination_2-bmv2.p4
-  gauntlet_exit_combination_22-bmv2.p4
-  gauntlet_exit_combination_23-bmv2.p4
-  gauntlet_exit_combination_3-bmv2.p4
-  gauntlet_exit_combination_4-bmv2.p4
-  gauntlet_exit_combination_9-bmv2.p4
-  gauntlet_index_2-bmv2.p4
-  gauntlet_inout_slice_table_key-bmv2.p4
-  gauntlet_instance_overwrite-bmv2.p4
-  gauntlet_mux_hdr-bmv2.p4
-  gauntlet_nested_switch-bmv2.p4
-  gauntlet_nested_table_calls-bmv2.p4
-  gauntlet_switch_exclusivity-bmv2.p4
-  gauntlet_switch_nested_table_apply-bmv2.p4
-  gauntlet_switch_shadowing-bmv2.p4
-  gauntlet_table_call_in_expression-bmv2.p4
-  gauntlet_uninitialized_bool_struct-bmv2.p4
-  gauntlet_variable_shadowing-bmv2.p4
-  graph-annotationless-key.p4
-  header-stack-ops-bmv2.p4
-  hit-expr-bmv2.p4
-  init-entries-bmv2.p4
-  inline-bmv2.p4
-  inline1-bmv2.p4
-  invalid-hdr-warnings1.p4
-  ipv6-switch-ml-bmv2.p4
-  issue-2123.p4
-  issue-3312-graph-bmv2.p4
-  issue1049-bmv2.p4
-  issue1062-1-bmv2.p4
-  issue1062-bmv2.p4
-  issue1107.p4
-  issue1193-bmv2.p4
-  issue1304.p4
-  issue1352-bmv2.p4
-  issue1412-bmv2.p4
-  issue1478-bmv2.p4
-  issue1538.p4
-  issue1544-1-bmv2.p4
-  issue1544-2-bmv2.p4
-  issue1544-bmv2.p4
-  issue1560-bmv2.p4
-  issue1595.p4
-  issue1653-complex-bmv2.p4
-  issue1713-bmv2.p4
-  issue1739-bmv2.p4
-  issue1765-1-bmv2.p4
-  issue1765-bmv2.p4
-  issue1814-1-bmv2.p4
-  issue1814-bmv2.p4
-  issue1829-4-bmv2.p4
-  issue1834-bmv2.p4
-  issue1882-1-bmv2.p4
-  issue1882-bmv2.p4
-  issue1958.p4
-  issue1985.p4
-  issue1989-bmv2.p4
-  issue2044-bmv2.p4
-  issue2153-bmv2.p4
-  issue2170-bmv2.p4
-  issue2258-bmv2.p4
-  issue2266.p4
-  issue2283_1-bmv2.p4
-  issue2314.p4
-  issue2321.p4
-  issue2344.p4
-  issue2362-bmv2.p4
-  issue2375-bmv2.p4
-  issue2495-bmv2.p4
-  issue2664-bmv2.p4
-  issue281.p4
-  issue2904.p4
-  issue2905-bmv2.p4
-  issue297-bmv2.p4
-  issue298-bmv2.p4
-  issue3091.p4
-  issue3374.p4
-  issue3488-1-bmv2.p4
-  issue3488-bmv2.p4
-  issue364-bmv2.p4
-  issue383-bmv2.p4
-  issue4057.p4
-  issue414-bmv2.p4
-  issue420.p4
-  issue422.p4
-  issue461-bmv2.p4
-  issue4739.p4
-  issue486-bmv2.p4
-  issue512.p4
-  issue561-1-bmv2.p4
-  issue561-2-bmv2.p4
-  issue561-3-bmv2.p4
-  issue561-4-bmv2.p4
-  issue561-5-bmv2.p4
-  issue561-6-bmv2.p4
-  issue561-7-bmv2.p4
-  issue561-bmv2.p4
-  issue949.p4
-  issue983-bmv2.p4
-  issue986-1-bmv2.p4
-  issue986-bmv2.p4
-  junk-prop-bmv2.p4
-  logging-bmv2.p4
-  match-on-exprs-bmv2.p4
-  match-on-exprs2-bmv2.p4
-  multicast-bmv2.p4
-  named_meter_1-bmv2.p4
-  named_meter_bmv2.p4
-  nonstandard_table_names-bmv2.p4
-  p416-type-use3.p4
-  parser-locals2.p4
-  parser-unroll-issue3537-1.p4
-  parser-unroll-issue3537.p4
-  parser-unroll-test10.p4
-  parser-unroll-test9.p4
-  pvs-bitstring-bmv2.p4
-  pvs-nested-struct.p4
-  pvs-struct-1-bmv2.p4
-  pvs-struct-2-bmv2.p4
-  pvs-struct-3-bmv2.p4
-  same_name_for_table_and_action.p4
-  saturated-bmv2.p4
-  slice-def-use1.p4
-  stack_complex-bmv2.p4
-  std_meta_inlining.p4
-  strength3.p4
-  strength6.p4
-  structured_annotations.p4
-  table-entries-exact-bmv2.p4
-  table-entries-exact-ternary-bmv2.p4
-  table-entries-lpm-bmv2.p4
-  table-entries-optional-bmv2.p4
-  table-entries-priority-bmv2.p4
-  table-entries-range-bmv2.p4
-  table-entries-ser-enum-bmv2.p4
-  table-entries-ternary-bmv2.p4
-  table-entries-valid-bmv2.p4
-  table-key-serenum-bmv2.p4
-  ternary2-bmv2.p4
-  union-valid-bmv2.p4
-  unused-counter-bmv2.p4
-  use-priority-as-name.p4
-  v1model-const-entries-bmv2.p4
-  v1model-digest-containing-ser-enum.p4
-  v1model-digest-custom-type.p4
-  v1model-p4runtime-enumint-types1.p4
-  v1model-p4runtime-most-types1.p4
-  v1model-special-ops-bmv2.p4
-  xor_test.p4
-  dash-pipeline-v1model-bmv2.p4
-  fabric.p4
-  up4.p4
-  pins_fabric.p4
-  pins_middleblock.p4
-  pins_wbb.p4
-  # Custom tests
-  v1model_constant_variable.p4
-  v1model_dead_ternary_table.p4
-  v1model_default_override.p4
-  v1model_entries_table.p4
-  v1model_simple_example.p4
 )
 
+p4tools_add_xfail_reason(
+  "rtsmith-checker-bmv2-v1model"
+  "Compiler Bug|Unimplemented compiler support"
+  issue1304.p4 # Cast failed: Pipeline<my_packet, my_metadata> with type Type_Specialized is not a
+               # Type_Declaration.
+  header-stack-ops-bmv2.p4 # Unknown method member expression: hdr_0.h2; of type header h2_t
+  issue4739.p4 # type ForStatement not implemented in the core stepper
+)
 
+# These are custom externs we do not implement.
+p4tools_add_xfail_reason(
+  "rtsmith-checker-bmv2-v1model"
+  "Unknown or unimplemented extern method: .*"
+  issue1882-bmv2.p4 # Unknown or unimplemented extern method: extr.increment
+  issue1882-1-bmv2.p4 # Unknown or unimplemented extern method: extr.increment
+  issue2664-bmv2.p4 # Unknown or unimplemented extern method: ipv4_checksum.update
+)
+
+p4tools_add_xfail_reason(
+  "rtsmith-checker-bmv2-v1model"
+  "Unable to find var .* in the symbolic environment"
+  union-valid-bmv2.p4 # Unable to find var h.u.*valid; in the symbolic environment.
+  issue3091.p4 # WONTFIX Unable to find var ternary; in the symbolic environment.
+)
+
+p4tools_add_xfail_reason(
+  "rtsmith-checker-bmv2-v1model"
+  "expected a header or header union stack"
+  issue4057.p4
+)
+
+p4tools_add_xfail_reason(
+  "rtsmith-checker-bmv2-v1model" "Only constants are supported"
+  parser-unroll-test10.p4 # Value meta.hs_next_index; is not a constant. Only constants are
+                          # supported as part of a state variable.
+                          # hdr.hs[meta.hs_next_index].setValid();
+)
+
+p4tools_add_xfail_reason(
+  "rtsmith-checker-bmv2-v1model"
+  "Unsupported type argument for Value Set"
+  pvs-nested-struct.p4
+)
+
+p4tools_add_xfail_reason(
+  "rtsmith-checker-bmv2-v1model"
+  "Parser state .* was already visited. We currently do not support parser loops."
+  issue2314.p4
+  invalid-hdr-warnings1.p4
+  parser-unroll-test9.p4
+  parser-unroll-issue3537.p4
+  parser-unroll-issue3537-1.p4
+  issue281.p4
+  fabric.p4
+)

--- a/targets/bmv2/test/P4Tests.cmake
+++ b/targets/bmv2/test/P4Tests.cmake
@@ -29,7 +29,7 @@ if (TARGET flay)
     # These tests time out and require fixing.
   )
 
-  set (EXTRA_OPTS "")
+  set (EXTRA_OPTS "--seed 1")
 
   p4tools_add_tests(
     TESTS

--- a/targets/tofino/fuzzer.cpp
+++ b/targets/tofino/fuzzer.cpp
@@ -37,15 +37,13 @@ bfrt_proto::KeyField_Ternary TofinoTnaFuzzer::produceKeyField_Ternary(int bitwid
 }
 
 bfrt_proto::KeyField_Range TofinoTnaFuzzer::produceKeyField_Range(int bitwidth) {
-    bfrt_proto::KeyField_Range protoTernary;
-    auto value1 = produceBytes(bitwidth);
-    auto value2 = produceBytes(bitwidth);
-    if (value1 > value2) {
-        std::swap(value1, value2);
-    }
-    protoTernary.set_low(value1);
-    protoTernary.set_high(value2);
-    return protoTernary;
+    bfrt_proto::KeyField_Range protoRange;
+    const auto &highValue = Utils::getRandConstantForWidth(bitwidth)->value;
+    auto low = produceBytes(bitwidth, /*min=*/0, /*max=*/highValue);
+    auto high = checkBigIntToString(highValue, bitwidth);
+    protoRange.set_low(low);
+    protoRange.set_high(high);
+    return protoRange;
 }
 
 bfrt_proto::KeyField_Optional TofinoTnaFuzzer::produceKeyField_Optional(int bitwidth) {

--- a/targets/tofino/fuzzer.cpp
+++ b/targets/tofino/fuzzer.cpp
@@ -36,6 +36,18 @@ bfrt_proto::KeyField_Ternary TofinoTnaFuzzer::produceKeyField_Ternary(int bitwid
     return protoTernary;
 }
 
+bfrt_proto::KeyField_Range TofinoTnaFuzzer::produceKeyField_Range(int bitwidth) {
+    bfrt_proto::KeyField_Range protoTernary;
+    auto value1 = produceBytes(bitwidth);
+    auto value2 = produceBytes(bitwidth);
+    if (value1 > value2) {
+        std::swap(value1, value2);
+    }
+    protoTernary.set_low(value1);
+    protoTernary.set_high(value2);
+    return protoTernary;
+}
+
 bfrt_proto::KeyField_Optional TofinoTnaFuzzer::produceKeyField_Optional(int bitwidth) {
     bfrt_proto::KeyField_Optional protoOptional;
     protoOptional.set_value(produceBytes(bitwidth));
@@ -82,6 +94,9 @@ bfrt_proto::KeyField TofinoTnaFuzzer::produceKeyField(const p4::config::v1::Matc
             break;
         case p4::config::v1::MatchField::TERNARY:
             protoKeyField.mutable_ternary()->CopyFrom(produceKeyField_Ternary(bitwidth));
+            break;
+        case p4::config::v1::MatchField::RANGE:
+            protoKeyField.mutable_range()->CopyFrom(produceKeyField_Range(bitwidth));
             break;
         case p4::config::v1::MatchField::OPTIONAL:
             protoKeyField.mutable_optional()->CopyFrom(produceKeyField_Optional(bitwidth));

--- a/targets/tofino/fuzzer.cpp
+++ b/targets/tofino/fuzzer.cpp
@@ -134,6 +134,10 @@ InitialConfig TofinoTnaFuzzer::produceInitialConfig() {
             continue;
         }
         auto table = tables.Get(tableId);
+        if (table.match_fields_size() == 0) {
+            // Skip tables without match fields
+            continue;
+        }
         /// TODO: remove this `min`. It is for ease of debugging now.
         auto maxEntryGenCnt = std::min(table.size(), (int64_t)4);
         std::set<std::string> matchFields;

--- a/targets/tofino/fuzzer.cpp
+++ b/targets/tofino/fuzzer.cpp
@@ -119,10 +119,6 @@ bfrt_proto::TableEntry TofinoTnaFuzzer::produceTableEntry(
     const auto &matchFields = table.match_fields();
     for (auto i = 0; i < matchFields.size(); i++) {
         auto match = matchFields[i];
-        /// TODO: add this back once Flay supports OPTIONAL.
-        if (match.match_type() == p4::config::v1::MatchField::OPTIONAL) {
-            continue;
-        }
         protoEntry.mutable_key()->add_fields()->CopyFrom(produceKeyField(matchFields[i]));
     }
 
@@ -152,10 +148,6 @@ InitialConfig TofinoTnaFuzzer::produceInitialConfig() {
         }
         auto table = tables.Get(tableId);
         if (table.match_fields_size() == 0 || table.is_const_table()) {
-            continue;
-        }
-        /// TODO: Remove this when Flay supports RANGE.
-        if (tableHasFieldType(table, p4::config::v1::MatchField::RANGE)) {
             continue;
         }
         /// TODO: remove this `min`. It is for ease of debugging now.

--- a/targets/tofino/fuzzer.cpp
+++ b/targets/tofino/fuzzer.cpp
@@ -134,8 +134,7 @@ InitialConfig TofinoTnaFuzzer::produceInitialConfig() {
             continue;
         }
         auto table = tables.Get(tableId);
-        if (table.match_fields_size() == 0) {
-            // Skip tables without match fields
+        if (table.match_fields_size() == 0 || table.is_const_table()) {
             continue;
         }
         /// TODO: remove this `min`. It is for ease of debugging now.

--- a/targets/tofino/fuzzer.h
+++ b/targets/tofino/fuzzer.h
@@ -14,20 +14,25 @@ class TofinoTnaFuzzer : public RuntimeFuzzer {
  public:
     explicit TofinoTnaFuzzer(const TofinoTnaProgramInfo &programInfo);
 
-    /// @brief Produce a `produceKeyField_Exact` with bitwidth.
+    /// @brief Produce a `KeyField_Exact` with bitwidth.
     /// @param bitwidth
-    /// @return A `produceKeyField_Exact`.
+    /// @return A `KeyField_Exact`.
     virtual bfrt_proto::KeyField_Exact produceKeyField_Exact(int bitwidth);
 
-    /// @brief Produce a `produceKeyField_LPM` with bitwidth.
+    /// @brief Produce a `KeyField_LPM` with bitwidth.
     /// @param bitwidth
-    /// @return A `produceKeyField_LPM`.
+    /// @return A `KeyField_LPM`.
     virtual bfrt_proto::KeyField_LPM produceKeyField_LPM(int bitwidth);
 
-    /// @brief Produce a `produceKeyField_Ternary` with bitwidth.
+    /// @brief Produce a `KeyField_Ternary` with bitwidth.
     /// @param bitwidth
-    /// @return A `produceKeyField_Ternary`.
+    /// @return A `KeyField_Ternary`.
     virtual bfrt_proto::KeyField_Ternary produceKeyField_Ternary(int bitwidth);
+
+    /// @brief Produce a `KeyField_Range` with bitwidth.
+    /// @param bitwidth
+    /// @return A `KeyField_Range`.
+    virtual bfrt_proto::KeyField_Range produceKeyField_Range(int bitwidth);
 
     /// @brief Produce a `KeyField_Optional` with bitwidth.
     /// @param bitwidth


### PR DESCRIPTION
1. Ensure entries to be unique
2. Skip table without match fields
3. Skip const table
4. Skip RANGE/OPTIONAL, which are not supported by Flay currently [Fixed]
5. Add random seed, otherwise, random int generator only generates 0
6. Fix xfails after above fixes